### PR TITLE
Refactor getIconSize tests with parameterized inputs

### DIFF
--- a/shared/__tests__/getIconSize.test.ts
+++ b/shared/__tests__/getIconSize.test.ts
@@ -2,23 +2,13 @@ import { describe, it, expect } from 'vitest';
 import { getIconSize, IconSizes } from '../utils/getIconSize';
 
 describe('getIconSize', () => {
-    it('returns Medium size (20) when iconSize is undefined', () => {
-        expect(getIconSize(undefined)).toBe(IconSizes.Medium);
-    });
-
-    it('returns 16 for Small', () => {
-        expect(getIconSize('Small')).toBe(IconSizes.Small);
-    });
-
-    it('returns 20 for Medium', () => {
-        expect(getIconSize('Medium')).toBe(IconSizes.Medium);
-    });
-
-    it('returns 24 for Large', () => {
-        expect(getIconSize('Large')).toBe(IconSizes.Large);
-    });
-
-    it('returns Medium size (20) for an empty string', () => {
-        expect(getIconSize('')).toBe(IconSizes.Medium);
+    it.each([
+        { input: undefined, expected: IconSizes.Medium, label: 'undefined' },
+        { input: 'Small', expected: IconSizes.Small, label: 'Small' },
+        { input: 'Medium', expected: IconSizes.Medium, label: 'Medium' },
+        { input: 'Large', expected: IconSizes.Large, label: 'Large' },
+        { input: '', expected: IconSizes.Medium, label: 'empty string' },
+    ])('returns $expected for $label', ({ input, expected }) => {
+        expect(getIconSize(input)).toBe(expected);
     });
 });


### PR DESCRIPTION
Refactor tests for getIconSize to use parameterized cases for better readability and maintainability.