### PR TITLE
feat: introduce ICONS and ICON_SIZES constants for improved icon handling

### DIFF
--- a/OptionsetColourControl/__tests__/DropdownButton.test.tsx
+++ b/OptionsetColourControl/__tests__/DropdownButton.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import { render } from '@testing-library/react';
 import { FluentProvider, webLightTheme } from '@fluentui/react-components';
 import { DropdownButton } from '../OptionsetColourControl/components/DropDownButton';
@@ -8,6 +8,14 @@ const renderWithFluentProvider = (ui: React.ReactElement) =>
     render(<FluentProvider theme={webLightTheme}>{ui}</FluentProvider>);
 
 describe('DropdownButton', () => {
+    let selectedOption: ComponentFramework.PropertyHelper.OptionMetadata;
+    beforeAll(() => {
+        selectedOption = {
+            Value: 1,
+            Label: 'Option 1',
+            Color: 'Red',
+        } as ComponentFramework.PropertyHelper.OptionMetadata;
+    });
     it.each([{ selectedKey: undefined }, { selectedKey: -1 }])(
         `renders "---" when selectedKey is %p`,
         ({ selectedKey }) => {
@@ -26,11 +34,6 @@ describe('DropdownButton', () => {
     );
 
     it('renders the option label when a valid option is selected', () => {
-        const selectedOption = {
-            Value: 1,
-            Label: 'Option 1',
-            Color: 'Red',
-        } as ComponentFramework.PropertyHelper.OptionMetadata;
         const { getByText } = renderWithFluentProvider(
             <DropdownButton
                 selectedKey={1}
@@ -45,11 +48,6 @@ describe('DropdownButton', () => {
     });
 
     it('renders an icon when backGroundFill is false and a valid option is selected', () => {
-        const selectedOption = {
-            Value: 1,
-            Label: 'Option 1',
-            Color: 'Red',
-        } as ComponentFramework.PropertyHelper.OptionMetadata;
         const { container } = renderWithFluentProvider(
             <DropdownButton
                 selectedKey={1}
@@ -64,11 +62,6 @@ describe('DropdownButton', () => {
     });
 
     it('does not render an icon when backGroundFill is true', () => {
-        const selectedOption = {
-            Value: 1,
-            Label: 'Option 1',
-            Color: 'Red',
-        } as ComponentFramework.PropertyHelper.OptionMetadata;
         const fillStyles: React.CSSProperties = { background: 'Red' };
         const { container } = renderWithFluentProvider(
             <DropdownButton

--- a/OptionsetColourControl/__tests__/OptionsetColour.test.tsx
+++ b/OptionsetColourControl/__tests__/OptionsetColour.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { webLightTheme } from '@fluentui/react-components';
 import { OptionsetColour } from '../OptionsetColourControl/components/OptionsetColour';
+import { ICONS } from '@pcf-optionsets/shared/constants';
 
 const mockOptions: ComponentFramework.PropertyHelper.OptionMetadata[] = [
     { Value: 1, Label: 'Option 1', Color: 'Red' } as ComponentFramework.PropertyHelper.OptionMetadata,
@@ -21,7 +22,7 @@ describe('OptionsetColour', () => {
                 onChange={onChange}
                 id="test-id"
                 iconSize="Medium"
-                iconType="CircleFilled"
+                iconType={ICONS.CIRCLE_FILLED}
                 backGroundFill={false}
                 disabled={false}
             />,
@@ -39,7 +40,7 @@ describe('OptionsetColour', () => {
                 onChange={onChange}
                 id="test-id"
                 iconSize="Medium"
-                iconType="CircleFilled"
+                iconType={ICONS.CIRCLE_FILLED}
                 backGroundFill={false}
                 disabled={false}
             />,
@@ -57,7 +58,7 @@ describe('OptionsetColour', () => {
                 onChange={onChange}
                 id="test-id"
                 iconSize="Medium"
-                iconType="CircleFilled"
+                iconType={ICONS.CIRCLE_FILLED}
                 backGroundFill={false}
                 disabled={false}
             />,
@@ -75,7 +76,7 @@ describe('OptionsetColour', () => {
                 onChange={onChange}
                 id="test-id"
                 iconSize="Medium"
-                iconType="CircleFilled"
+                iconType={ICONS.CIRCLE_FILLED}
                 backGroundFill={false}
                 disabled={true}
             />,

--- a/shared/__tests__/IconType.test.tsx
+++ b/shared/__tests__/IconType.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { IconType } from '../components/IconType';
+import { ICONS } from '../constants';
 
 describe('IconType', () => {
     it('renders without crashing', () => {
@@ -9,15 +10,18 @@ describe('IconType', () => {
         expect(container.firstChild).not.toBeNull();
     });
 
-    it.each([{ icon: 'CircleFilled' }, { icon: 'OvalFilled' }])(`should render with each $icon`, ({ icon }) => {
-        const { container } = render(<IconType icon={icon} />);
-        const svg = container.querySelector('svg');
-        expect(svg).not.toBeNull();
-    });
+    it.each([{ icon: ICONS.CIRCLE_FILLED }, { icon: ICONS.OVAL_FILLED }])(
+        `should render with each $icon`,
+        ({ icon }) => {
+            const { container } = render(<IconType icon={icon} />);
+            const svg = container.querySelector('svg');
+            expect(svg).not.toBeNull();
+        },
+    );
 
     it.each([
-        { icon: 'CircleFilled', colour: 'red', expected: 'rgb(255,0,0)' },
-        { icon: 'OvalFilled', colour: 'blue', expected: 'rgb(0,0,255)' },
+        { icon: ICONS.CIRCLE_FILLED, colour: 'red', expected: 'rgb(255,0,0)' },
+        { icon: ICONS.OVAL_FILLED, colour: 'blue', expected: 'rgb(0,0,255)' },
     ])('applies color $colour to $icon', ({ icon, colour, expected }) => {
         const { container } = render(<IconType icon={icon} style={{ color: colour }} />);
         const svg = container.querySelector('svg');

--- a/shared/__tests__/getIconSize.test.ts
+++ b/shared/__tests__/getIconSize.test.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { getIconSize, IconSizes } from '../utils/getIconSize';
+import { getIconSize } from '../utils/getIconSize';
+import { ICON_SIZES } from '../constants';
 
 describe('getIconSize', () => {
     it.each([
-        { input: undefined, expected: IconSizes.Medium, label: 'undefined' },
-        { input: 'Small', expected: IconSizes.Small, label: 'Small' },
-        { input: 'Medium', expected: IconSizes.Medium, label: 'Medium' },
-        { input: 'Large', expected: IconSizes.Large, label: 'Large' },
-        { input: '', expected: IconSizes.Medium, label: 'empty string' },
+        { input: undefined, expected: ICON_SIZES.Medium, label: 'undefined' },
+        { input: 'Small', expected: ICON_SIZES.Small, label: 'Small' },
+        { input: 'Medium', expected: ICON_SIZES.Medium, label: 'Medium' },
+        { input: 'Large', expected: ICON_SIZES.Large, label: 'Large' },
+        { input: '', expected: ICON_SIZES.Medium, label: 'empty string' },
     ])('returns $expected for $label', ({ input, expected }) => {
         expect(getIconSize(input)).toBe(expected);
     });

--- a/shared/components/IconType.tsx
+++ b/shared/components/IconType.tsx
@@ -1,12 +1,13 @@
 import { CircleFilled, CircleRegular, FluentIcon, OvalFilled } from '@fluentui/react-icons';
 import * as React from 'react';
+import { ICONS } from '../constants';
 
 export interface IIconTypeProps extends React.ComponentProps<FluentIcon> {
     icon: string | undefined;
 }
 
 export const IconType: React.FC<IIconTypeProps> = ({ icon, ...props }) => {
-    const Icon = icon === 'CircleFilled' ? CircleFilled : OvalFilled;
+    const Icon = icon === ICONS.CIRCLE_FILLED ? CircleFilled : OvalFilled;
 
     return <Icon {...props}></Icon>;
 };

--- a/shared/constants/icons.ts
+++ b/shared/constants/icons.ts
@@ -1,0 +1,10 @@
+export const ICONS = {
+    CIRCLE_FILLED: 'CircleFilled',
+    OVAL_FILLED: 'OvalFilled',
+};
+
+export const ICON_SIZES: Record<string, number> = {
+    Small: 16,
+    Medium: 20,
+    Large: 24,
+};

--- a/shared/constants/index.ts
+++ b/shared/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './icons';

--- a/shared/utils/getIconSize.ts
+++ b/shared/utils/getIconSize.ts
@@ -1,5 +1,10 @@
-export const IconSizes: Record<string, number> = { Small: 16, Medium: 20, Large: 24 };
+import { ICON_SIZES } from '../constants';
 
+/**
+ *
+ * @param iconSize {string | undefined} - The size of the icon, can be 'Small', 'Medium', 'Large' or undefined.
+ * @returns The numeric size associated with the provided icon size.
+ */
 export const getIconSize = (iconSize: string | undefined): number => {
-    return iconSize ? IconSizes[iconSize] : IconSizes.Medium;
+    return iconSize ? ICON_SIZES[iconSize] : ICON_SIZES.Medium;
 };


### PR DESCRIPTION
This pull request centralizes icon-related constants by introducing a new `icons.ts` file and refactoring existing code to use these shared constants. This improves maintainability and consistency across components and tests. The most important changes are grouped below:

**Introduction of shared icon constants:**

* Added a new `shared/constants/icons.ts` file that exports `ICONS` (icon name strings) and `ICON_SIZES` (icon size mappings).
* Re-exported the new constants from `shared/constants/index.ts` for easier imports throughout the codebase.

**Refactoring to use shared constants:**

* Updated `IconType` component in `shared/components/IconType.tsx` to use `ICONS` instead of hardcoded icon name strings.
* Refactored tests in `shared/__tests__/IconType.test.tsx` and `shared/__tests__/getIconSize.test.ts` to use `ICONS` and `ICON_SIZES` respectively, improving consistency and reducing duplication. [[1]](diffhunk://#diff-246f18f2ad4df7347908bbd6b131168161de07c93f8e762fe896bc5b1fd3bf12R5-R24) [[2]](diffhunk://#diff-c04e43fe89f34384b663f33c418cedf37734c9eb02aa9ef588d988b9964226f5L2-R11)
* Updated `getIconSize` utility in `shared/utils/getIconSize.ts` to use the new `ICON_SIZES` constant, removing the previously inline definition.…ling
This pull request refactors how icon types and sizes are managed and referenced throughout the codebase, introducing centralized constants for better maintainability and consistency. It updates both implementation and test files to use these new constants, and improves test code structure by reducing duplication.

**Centralization of icon constants and sizes:**

* Introduced `ICONS` and `ICON_SIZES` objects in `shared/constants/icons.ts` to standardize icon type and size references across the codebase.
* Re-exported these constants via `shared/constants/index.ts` for easier imports.

**Refactoring of icon usage in components and utilities:**

* Updated `shared/components/IconType.tsx` to use the new `ICONS` constant instead of hardcoded icon type strings.
* Modified `shared/utils/getIconSize.ts` to use `ICON_SIZES` instead of the previously local `IconSizes` object, and added documentation for the function.

**Test updates for consistency and maintainability:**

* Refactored all relevant test files (`OptionsetColourControl/__tests__/OptionsetColour.test.tsx`, `shared/__tests__/IconType.test.tsx`, `shared/__tests__/getIconSize.test.ts`) to use the new `ICONS` and `ICON_SIZES` constants, replacing hardcoded strings and local enums. [[1]](diffhunk://#diff-f04a6991f434473a618276a4bd4d20868768fa2da80db5780ffd59caa308ce95R6) [[2]](diffhunk://#diff-f04a6991f434473a618276a4bd4d20868768fa2da80db5780ffd59caa308ce95L24-R25) [[3]](diffhunk://#diff-f04a6991f434473a618276a4bd4d20868768fa2da80db5780ffd59caa308ce95L42-R43) [[4]](diffhunk://#diff-f04a6991f434473a618276a4bd4d20868768fa2da80db5780ffd59caa308ce95L60-R61) [[5]](diffhunk://#diff-f04a6991f434473a618276a4bd4d20868768fa2da80db5780ffd59caa308ce95L78-R79) [[6]](diffhunk://#diff-246f18f2ad4df7347908bbd6b131168161de07c93f8e762fe896bc5b1fd3bf12R5-R24) [[7]](diffhunk://#diff-c04e43fe89f34384b663f33c418cedf37734c9eb02aa9ef588d988b9964226f5L2-R11)
* Improved test code in `OptionsetColourControl/__tests__/DropdownButton.test.tsx` by moving repeated option object creation to a `beforeAll` block, reducing duplication and improving clarity. [[1]](diffhunk://#diff-112d4a3e70d6463c99e96433e848587e5ae2164319d0105a251f5105f1ed9959L2-R2) [[2]](diffhunk://#diff-112d4a3e70d6463c99e96433e848587e5ae2164319d0105a251f5105f1ed9959R11-R18) [[3]](diffhunk://#diff-112d4a3e70d6463c99e96433e848587e5ae2164319d0105a251f5105f1ed9959L29-L33) [[4]](diffhunk://#diff-112d4a3e70d6463c99e96433e848587e5ae2164319d0105a251f5105f1ed9959L48-L52) [[5]](diffhunk://#diff-112d4a3e70d6463c99e96433e848587e5ae2164319d0105a251f5105f1ed9959L67-L71)